### PR TITLE
RegexTest: python3.6 compatibility

### DIFF
--- a/mox3/tests/test_mox.py
+++ b/mox3/tests/test_mox.py
@@ -312,12 +312,12 @@ class RegexTest(testtools.TestCase):
     def testReprWithoutFlags(self):
         """repr should return the regular expression pattern."""
         self.assertTrue(
-            repr(mox.Regex(r"a\s+b")) == "<regular expression 'a\s+b'>")
+            repr(mox.Regex(r"a\s+b")) == r"<regular expression 'a\s+b'>")
 
     def testReprWithFlags(self):
         """repr should return the regular expression pattern and flags."""
-        self.assertTrue(repr(mox.Regex(r"a\s+b", flags=4)) ==
-                        "<regular expression 'a\s+b', flags=4>")
+        self.assertTrue(repr(mox.Regex(r"a\s+b", flags=8)) ==
+                        r"<regular expression 'a\s+b', flags=8>")
 
 
 class IsTest(testtools.TestCase):


### PR DESCRIPTION
These fixes are backward-compatible with older python versions:

* raw strings fix invalid escape sequences
* flags=8 fixes ValueError: cannot use LOCALE flag with a str pattern